### PR TITLE
Update incorrect documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,9 @@ Usage
 Example of sending message:
 
 ```javascript
-var springedge = require('springedge');
-```
-
-```javascript
 // send sms
 
-var springedge = require('springedge');
+var springedge = require('springedge')();
 
 var params = {
   'apikey': '', // API Key

--- a/send_messages.js
+++ b/send_messages.js
@@ -1,6 +1,6 @@
 //npm install springedge
 
-var springedge = require('springedge');
+var springedge = require('springedge')();
 
 var params = {
   'apikey': '636n033l3549o14yp1ljdti3t81rk11v5', //TEST API Key


### PR DESCRIPTION
The examples/documentation is incorrect, and this PR was spawned from [this Stackoverflow question](https://stackoverflow.com/questions/45059451/typeerror-cannot-read-property-send-of-undefined-nodejs/45059583).

The API does not use the `accessKey` that the exported function expects, which could be removed. However it is not backwards-compatible and would be a breaking change. I could close this PR and create a new one that has this breaking change introduced.